### PR TITLE
버블 랜덤 배치 구현 및 기타 수정

### DIFF
--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -9,10 +9,6 @@ import SwiftUI
 import RealityKit
 import RealityKitContent
 
-import SwiftUI
-import RealityKit
-import RealityKitContent
-
 struct ContentView: View {
     @Environment(ContentViewModel.self) var viewModel: ContentViewModel
     @State private var showImmersiveSpace = false
@@ -22,10 +18,6 @@ struct ContentView: View {
 
     var body: some View {
         RealityView { content in
-            // Add the initial RealityKit content
-//            if let scene = try? await Entity(named: "Scene", in: realityKitContentBundle) {
-//                content.add(scene)
-//            }
             let bubbleEntity = viewModel.makeBubble("Welcome")
             bubbleEntity.scale = SIMD3(repeating: 1)
             let textModelEntity = viewModel.makeTextEntity(text: "Welcome", scale: 0.3)
@@ -48,6 +40,7 @@ struct ContentView: View {
                         showImmersiveSpace = false
                     }
                 } else if viewModel.immersiveSpaceIsShown {
+                    viewModel.isResetImmersiveContents = true
                     await dismissImmersiveSpace()
                     viewModel.immersiveSpaceIsShown = false
                 }

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -12,7 +12,6 @@ import RealityKitContent
 struct ContentView: View {
     @Environment(ContentViewModel.self) var viewModel: ContentViewModel
     @State private var showImmersiveSpace = false
-
     @Environment(\.openImmersiveSpace) var openImmersiveSpace
     @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
 
@@ -32,17 +31,14 @@ struct ContentView: View {
                 if newValue {
                     switch await openImmersiveSpace(id: "ImmersiveSpace") {
                     case .opened:
-                        viewModel.immersiveSpaceIsShown = true
+                        debugPrint("ImmersiveSpace opened")
                     case .error, .userCancelled:
                         fallthrough
                     @unknown default:
-                        viewModel.immersiveSpaceIsShown = false
                         showImmersiveSpace = false
                     }
-                } else if viewModel.immersiveSpaceIsShown {
-                    viewModel.isResetImmersiveContents = true
+                } else {
                     await dismissImmersiveSpace()
-                    viewModel.immersiveSpaceIsShown = false
                 }
             }
         }

--- a/AR-BoardGame/AR-BoardGame/View/ImmersiveView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ImmersiveView.swift
@@ -30,7 +30,13 @@ struct ImmersiveView: View {
                 
             }
             .onEnded { event in
-                viewModel.removeChildEntity(removedChild: event.entity)
+                // 터치 엔터티 삭제
+                event.entity.removeFromParent()
+                viewModel.addParticleEntity(transForm: event.entity.transform) { entity in
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        entity.removeFromParent()
+                    }
+                }
             }
         )
         .onChange(of: viewModel.isResetImmersiveContents) { _ ,newValue in

--- a/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
+++ b/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
@@ -47,7 +47,7 @@ class ContentViewModel {
             )
             
             modelEntity.generateCollisionShapes(recursive: true)
-            modelEntity.components.set(InputTargetComponent(allowedInputTypes: .indirect))
+            modelEntity.components.set(InputTargetComponent(allowedInputTypes: .all))
             
             childList.append(modelEntity)
             contentEntity.addChild(modelEntity)


### PR DESCRIPTION
## 🔥 작업한 내용
- 엔터티에 대한 인풋이 아이 트래킹을 이용한 간접 터치 뿐 아니라 손으로 직접 터치할 수 있도록 설정 변경
- 기존의 정해진 위치에 숫자만 랜덤으로 바꾸는게 아니라 위치도 랜덤하게 배치하도록 변경
- 대신 배치하는 위치가 서로 너무 붙어있지 않게 하는 로직 추가
- immersiveSpaceIsShown Bool 값과 childList 값이 필요가 없었던 값이라 삭제

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- ShowImmersive 토글을 통해 ImmersiveSpace를 닫았다가 다시 열었을때 ContentEnity에 추가했던 Particle Emmiter가 실행되는 버그 발생
->  원인은 현재 버블 엔터티를 터치할 때 기존에 추가되었던 particle 엔터티를 지우고, addParticleEntity를 통해 파티클을 추가해서 실행시키는데 결국 버블을 터치할때만 기존에 추가된게 지워지기 때문에 Show ImmersiveSpace 토글을 통해 ImmersiveSpace를 끄고 켰을 때 각 엔터티 마다 마지막에 추가되었던 Particle Emitter는 지워지지 않고 다시 실행이 됨
-> 때문에 아예 클로저를 이용해 addParticleEntity을 실행시키고, DispatchQueue를 이용해 파티클 duration인, 1.0보다 여유롭게 1.5초 이후에  추가된 파티클을 넘겨 받아서 removeFromParent를 이용해 삭제


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #2


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
