### PR TITLE
[Feat] 타이머 뷰 구현 및 기타 로직 수정

### DIFF
--- a/AR-BoardGame/AR-BoardGame.xcodeproj/project.pbxproj
+++ b/AR-BoardGame/AR-BoardGame.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E72D91062CACEEEE00149ADF /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D91052CACEEEE00149ADF /* TimerView.swift */; };
+		E72D910A2CAD618500149ADF /* TimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D91092CAD618500149ADF /* TimerViewModel.swift */; };
 		E764E5422C89208300A3CBEE /* EntityCoordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E764E5412C89208300A3CBEE /* EntityCoordinate.swift */; };
 		E7BEE1862C5FC6C300A4DBC8 /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = E7BEE1852C5FC6C300A4DBC8 /* RealityKitContent */; };
 		E7BEE1882C5FC6C300A4DBC8 /* AR_BoardGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEE1872C5FC6C300A4DBC8 /* AR_BoardGameApp.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		E72D91052CACEEEE00149ADF /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
+		E72D91092CAD618500149ADF /* TimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerViewModel.swift; sourceTree = "<group>"; };
 		E764E5412C89208300A3CBEE /* EntityCoordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityCoordinate.swift; sourceTree = "<group>"; };
 		E7BEE1802C5FC6C300A4DBC8 /* AR-BoardGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AR-BoardGame.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7BEE1842C5FC6C300A4DBC8 /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
@@ -50,6 +52,7 @@
 			isa = PBXGroup;
 			children = (
 				E7BEE1982C5FD32F00A4DBC8 /* ContentViewModel.swift */,
+				E72D91092CAD618500149ADF /* TimerViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -194,6 +197,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E72D910A2CAD618500149ADF /* TimerViewModel.swift in Sources */,
 				E72D91062CACEEEE00149ADF /* TimerView.swift in Sources */,
 				E7BEE1992C5FD32F00A4DBC8 /* ContentViewModel.swift in Sources */,
 				E764E5422C89208300A3CBEE /* EntityCoordinate.swift in Sources */,

--- a/AR-BoardGame/AR-BoardGame.xcodeproj/project.pbxproj
+++ b/AR-BoardGame/AR-BoardGame.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E72D91062CACEEEE00149ADF /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D91052CACEEEE00149ADF /* TimerView.swift */; };
 		E72D910A2CAD618500149ADF /* TimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D91092CAD618500149ADF /* TimerViewModel.swift */; };
+		E7374AC22CB4DB3D000A2F18 /* SceneID.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7374AC12CB4DB3D000A2F18 /* SceneID.swift */; };
 		E764E5422C89208300A3CBEE /* EntityCoordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E764E5412C89208300A3CBEE /* EntityCoordinate.swift */; };
 		E7BEE1862C5FC6C300A4DBC8 /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = E7BEE1852C5FC6C300A4DBC8 /* RealityKitContent */; };
 		E7BEE1882C5FC6C300A4DBC8 /* AR_BoardGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEE1872C5FC6C300A4DBC8 /* AR_BoardGameApp.swift */; };
@@ -23,6 +24,7 @@
 /* Begin PBXFileReference section */
 		E72D91052CACEEEE00149ADF /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		E72D91092CAD618500149ADF /* TimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerViewModel.swift; sourceTree = "<group>"; };
+		E7374AC12CB4DB3D000A2F18 /* SceneID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneID.swift; sourceTree = "<group>"; };
 		E764E5412C89208300A3CBEE /* EntityCoordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityCoordinate.swift; sourceTree = "<group>"; };
 		E7BEE1802C5FC6C300A4DBC8 /* AR-BoardGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AR-BoardGame.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7BEE1842C5FC6C300A4DBC8 /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
@@ -48,6 +50,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E7374AC02CB4DB13000A2F18 /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				E7374AC12CB4DB3D000A2F18 /* SceneID.swift */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
 		E764E53E2C89201800A3CBEE /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -99,6 +109,7 @@
 				E764E5402C89203200A3CBEE /* Model */,
 				E764E53F2C89202C00A3CBEE /* View */,
 				E764E53E2C89201800A3CBEE /* ViewModel */,
+				E7374AC02CB4DB13000A2F18 /* Constants */,
 				E7BEE18D2C5FC6C500A4DBC8 /* Assets.xcassets */,
 				E7BEE1922C5FC6C500A4DBC8 /* Info.plist */,
 				E7BEE19A2C5FD3E300A4DBC8 /* player_pawn_blue.usdz */,
@@ -200,6 +211,7 @@
 				E72D910A2CAD618500149ADF /* TimerViewModel.swift in Sources */,
 				E72D91062CACEEEE00149ADF /* TimerView.swift in Sources */,
 				E7BEE1992C5FD32F00A4DBC8 /* ContentViewModel.swift in Sources */,
+				E7374AC22CB4DB3D000A2F18 /* SceneID.swift in Sources */,
 				E764E5422C89208300A3CBEE /* EntityCoordinate.swift in Sources */,
 				E7BEE18A2C5FC6C400A4DBC8 /* ContentView.swift in Sources */,
 				E7BEE1882C5FC6C300A4DBC8 /* AR_BoardGameApp.swift in Sources */,

--- a/AR-BoardGame/AR-BoardGame.xcodeproj/project.pbxproj
+++ b/AR-BoardGame/AR-BoardGame.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E72D91062CACEEEE00149ADF /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D91052CACEEEE00149ADF /* TimerView.swift */; };
 		E764E5422C89208300A3CBEE /* EntityCoordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E764E5412C89208300A3CBEE /* EntityCoordinate.swift */; };
 		E7BEE1862C5FC6C300A4DBC8 /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = E7BEE1852C5FC6C300A4DBC8 /* RealityKitContent */; };
 		E7BEE1882C5FC6C300A4DBC8 /* AR_BoardGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEE1872C5FC6C300A4DBC8 /* AR_BoardGameApp.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E72D91052CACEEEE00149ADF /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		E764E5412C89208300A3CBEE /* EntityCoordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityCoordinate.swift; sourceTree = "<group>"; };
 		E7BEE1802C5FC6C300A4DBC8 /* AR-BoardGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AR-BoardGame.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7BEE1842C5FC6C300A4DBC8 /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
@@ -57,6 +59,7 @@
 			children = (
 				E7BEE1892C5FC6C400A4DBC8 /* ContentView.swift */,
 				E7BEE18B2C5FC6C400A4DBC8 /* ImmersiveView.swift */,
+				E72D91052CACEEEE00149ADF /* TimerView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -191,6 +194,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E72D91062CACEEEE00149ADF /* TimerView.swift in Sources */,
 				E7BEE1992C5FD32F00A4DBC8 /* ContentViewModel.swift in Sources */,
 				E764E5422C89208300A3CBEE /* EntityCoordinate.swift in Sources */,
 				E7BEE18A2C5FC6C400A4DBC8 /* ContentView.swift in Sources */,

--- a/AR-BoardGame/AR-BoardGame/AR_BoardGameApp.swift
+++ b/AR-BoardGame/AR-BoardGame/AR_BoardGameApp.swift
@@ -10,21 +10,21 @@ import SwiftUI
 @main
 struct AR_BoardGameApp: App {
     
-    @State private var contentViewModoel = ContentViewModel()
+    @State private var contentViewModel = ContentViewModel()
     @State private var timerViewModel = TimerViewModel()
     
     var body: some Scene {
-        WindowGroup(id: "ContentWindow") {
-            ContentView(contentViewModel: contentViewModoel)
+        WindowGroup(id: SceneID.WindowGroup.content.id) {
+            ContentView(contentViewModel: contentViewModel)
         }.windowStyle(.volumetric)
 
-        ImmersiveSpace(id: "ImmersiveSpace") {
+        ImmersiveSpace(id: SceneID.ImmersiveSpace.game.id) {
             ImmersiveView()
-                .environment(contentViewModoel)
+                .environment(contentViewModel)
         }
         
-        WindowGroup(id: "TimerWindow") {
-            TimerView(contentViewModel: contentViewModoel)
+        WindowGroup(id: SceneID.WindowGroup.timer.id) {
+            TimerView(contentViewModel: contentViewModel)
                 .environment(timerViewModel)
         }
     }

--- a/AR-BoardGame/AR-BoardGame/AR_BoardGameApp.swift
+++ b/AR-BoardGame/AR-BoardGame/AR_BoardGameApp.swift
@@ -11,16 +11,24 @@ import SwiftUI
 struct AR_BoardGameApp: App {
     
     @State private var contentViewMdoel = ContentViewModel()
-    
+    @State private var timerViewModel = TimerViewModel()
+    @State private var showImmersiveSpace = false
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(showImmersiveSpace: $showImmersiveSpace)
                 .environment(contentViewMdoel)
         }.windowStyle(.volumetric)
 
         ImmersiveSpace(id: "ImmersiveSpace") {
             ImmersiveView()
                 .environment(contentViewMdoel)
+                .environment(timerViewModel)
+        }
+        
+        WindowGroup(id: "TimerWindow") {
+            TimerView(showImmersiveSpace: $showImmersiveSpace)
+                .environment(contentViewMdoel)
+                .environment(timerViewModel)
         }
     }
 }

--- a/AR-BoardGame/AR-BoardGame/AR_BoardGameApp.swift
+++ b/AR-BoardGame/AR-BoardGame/AR_BoardGameApp.swift
@@ -10,24 +10,21 @@ import SwiftUI
 @main
 struct AR_BoardGameApp: App {
     
-    @State private var contentViewMdoel = ContentViewModel()
+    @State private var contentViewModoel = ContentViewModel()
     @State private var timerViewModel = TimerViewModel()
-    @State private var showImmersiveSpace = false
+    
     var body: some Scene {
-        WindowGroup {
-            ContentView(showImmersiveSpace: $showImmersiveSpace)
-                .environment(contentViewMdoel)
+        WindowGroup(id: "ContentWindow") {
+            ContentView(contentViewModel: contentViewModoel)
         }.windowStyle(.volumetric)
 
         ImmersiveSpace(id: "ImmersiveSpace") {
             ImmersiveView()
-                .environment(contentViewMdoel)
-                .environment(timerViewModel)
+                .environment(contentViewModoel)
         }
         
         WindowGroup(id: "TimerWindow") {
-            TimerView(showImmersiveSpace: $showImmersiveSpace)
-                .environment(contentViewMdoel)
+            TimerView(contentViewModel: contentViewModoel)
                 .environment(timerViewModel)
         }
     }

--- a/AR-BoardGame/AR-BoardGame/Constants/SceneID.swift
+++ b/AR-BoardGame/AR-BoardGame/Constants/SceneID.swift
@@ -1,0 +1,30 @@
+//
+//  SceneID.swift
+//  AR-BoardGame
+//
+//  Created by Damin on 10/8/24.
+//
+
+// SceneID.swift
+enum SceneID {
+  enum WindowGroup {
+    case content
+    case timer
+    var id: String {
+      switch self {
+      case .content: return "Content"
+      case .timer: return "Timer"
+      }
+    }
+  }
+  
+  enum ImmersiveSpace {
+    case game
+    
+    var id: String {
+      switch self {
+      case .game: return "Game"
+      }
+    }
+  }
+}

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -10,55 +10,46 @@ import RealityKit
 import RealityKitContent
 
 struct ContentView: View {
-  @Environment(ContentViewModel.self) var viewModel: ContentViewModel
-  @State private var showImmersiveSpace = false
-  @Environment(\.openImmersiveSpace) var openImmersiveSpace
-  @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
-  
-  var body: some View {
-    RealityView { content in
-      let bubbleEntity = viewModel.makeBubble("Welcome")
-      bubbleEntity.scale = SIMD3(repeating: 1)
-      let textModelEntity = viewModel.makeTextEntity(text: "Welcome", scale: 0.3)
-      bubbleEntity.addChild(textModelEntity)
-        bubbleEntity.position = SIMD3<Float>(x: bubbleEntity.position.x, y: bubbleEntity.position.y - 0.1, z: bubbleEntity.position.z + 0.1)
-      content.add(bubbleEntity)
-    } update: { content in
-      
-    }
-    .onChange(of: showImmersiveSpace) { _, newValue in
-      Task {
-        if newValue {
-          switch await openImmersiveSpace(id: "ImmersiveSpace") {
-          case .opened:
-            debugPrint("ImmersiveSpace opened")
-          case .error, .userCancelled:
-            fallthrough
-          @unknown default:
-            showImmersiveSpace = false
-          }
-        } else {
-          await dismissImmersiveSpace()
+    @Environment(ContentViewModel.self) var viewModel: ContentViewModel
+    @Environment(\.openWindow) var openWindow
+    @Environment(\.dismissWindow) var dismissWindow
+    @Environment(\.openImmersiveSpace) var openImmersiveSpace
+    @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
+    @Binding var showImmersiveSpace: Bool
+    
+    var body: some View {
+        RealityView { content in
+            let bubbleEntity = viewModel.makeBubble("Welcome")
+            bubbleEntity.scale = SIMD3(repeating: 1)
+            let textModelEntity = viewModel.makeTextEntity(text: "Welcome", scale: 0.3)
+            bubbleEntity.addChild(textModelEntity)
+            bubbleEntity.position = SIMD3<Float>(x: bubbleEntity.position.x, y: bubbleEntity.position.y - 0.1, z: bubbleEntity.position.z + 0.1)
+            content.add(bubbleEntity)
         }
-      }
-    }
-    .toolbar {
-      ToolbarItemGroup(placement: .bottomOrnament) {
-        VStack (spacing: 12) {
-          Toggle("Show ImmersiveSpace", isOn: $showImmersiveSpace)
-            if showImmersiveSpace {
-                Button("Reset ImmersiveNumber") {
-                  viewModel.isResetImmersiveContents = true
+        .onChange(of: showImmersiveSpace) { _, newValue in
+            Task {
+                if newValue {
+                    openWindow(id: "TimerWindow")
+                    switch await openImmersiveSpace(id: "ImmersiveSpace") {
+                    case .opened:
+                        debugPrint("ImmersiveSpace opened")
+                    case .error, .userCancelled:
+                        fallthrough
+                    @unknown default:
+                        showImmersiveSpace = false
+                    }
+                } else {
+                    dismissWindow(id: "TimerWindow")
+                    await dismissImmersiveSpace()
                 }
             }
-          
+            
         }
-      }
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomOrnament) {
+                Toggle("Start Game", isOn: $showImmersiveSpace)
+            }
+        }
     }
-  }
 }
 
-#Preview(windowStyle: .volumetric) {
-  ContentView()
-    .environment(ContentViewModel())
-}

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -22,7 +22,9 @@ struct ContentView: View {
             bubbleEntity.addChild(textModelEntity)
             bubbleEntity.position = SIMD3<Float>(x: bubbleEntity.position.x, y: bubbleEntity.position.y - 0.1, z: bubbleEntity.position.z + 0.1)
             bubbleEntity.generateCollisionShapes(recursive: true)
-            bubbleEntity.components.set(InputTargetComponent(allowedInputTypes: .all))
+            let inputTargetComponent = InputTargetComponent(allowedInputTypes: .all)
+            let hoverEffectComponent = HoverEffectComponent()
+            bubbleEntity.components.set([inputTargetComponent, hoverEffectComponent])
             bubbleEntity.name = "Welcome"
             contentEntity.addChild(bubbleEntity)
             content.add(contentEntity)

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
       bubbleEntity.scale = SIMD3(repeating: 1)
       let textModelEntity = viewModel.makeTextEntity(text: "Welcome", scale: 0.3)
       bubbleEntity.addChild(textModelEntity)
-      
+        bubbleEntity.position = SIMD3<Float>(x: bubbleEntity.position.x, y: bubbleEntity.position.y - 0.1, z: bubbleEntity.position.z + 0.1)
       content.add(bubbleEntity)
     } update: { content in
       
@@ -46,9 +46,12 @@ struct ContentView: View {
       ToolbarItemGroup(placement: .bottomOrnament) {
         VStack (spacing: 12) {
           Toggle("Show ImmersiveSpace", isOn: $showImmersiveSpace)
-          Button("Reset ImmersiveNumber") {
-            viewModel.isResetImmersiveContents = true
-          }
+            if showImmersiveSpace {
+                Button("Reset ImmersiveNumber") {
+                  viewModel.isResetImmersiveContents = true
+                }
+            }
+          
         }
       }
     }

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -10,46 +10,73 @@ import RealityKit
 import RealityKitContent
 
 struct ContentView: View {
-    @Environment(ContentViewModel.self) var viewModel: ContentViewModel
     @Environment(\.openWindow) var openWindow
-    @Environment(\.dismissWindow) var dismissWindow
-    @Environment(\.openImmersiveSpace) var openImmersiveSpace
-    @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
-    @Binding var showImmersiveSpace: Bool
+    @Bindable var contentViewModel: ContentViewModel
+    @State private var contentEntity = Entity()
     
     var body: some View {
         RealityView { content in
-            let bubbleEntity = viewModel.makeBubble("Welcome")
+            let bubbleEntity = contentViewModel.makeBubble("Welcome")
             bubbleEntity.scale = SIMD3(repeating: 1)
-            let textModelEntity = viewModel.makeTextEntity(text: "Welcome", scale: 0.3)
+            let textModelEntity = contentViewModel.makeTextEntity(text: "Welcome", scale: 0.3)
             bubbleEntity.addChild(textModelEntity)
             bubbleEntity.position = SIMD3<Float>(x: bubbleEntity.position.x, y: bubbleEntity.position.y - 0.1, z: bubbleEntity.position.z + 0.1)
-            content.add(bubbleEntity)
+            bubbleEntity.generateCollisionShapes(recursive: true)
+            bubbleEntity.components.set(InputTargetComponent(allowedInputTypes: .all))
+            bubbleEntity.name = "Welcome"
+            contentEntity.addChild(bubbleEntity)
+            content.add(contentEntity)
         }
-        .onChange(of: showImmersiveSpace) { _, newValue in
-            Task {
-                if newValue {
-                    openWindow(id: "TimerWindow")
-                    switch await openImmersiveSpace(id: "ImmersiveSpace") {
-                    case .opened:
-                        debugPrint("ImmersiveSpace opened")
-                    case .error, .userCancelled:
-                        fallthrough
-                    @unknown default:
-                        showImmersiveSpace = false
-                    }
-                } else {
-                    dismissWindow(id: "TimerWindow")
-                    await dismissImmersiveSpace()
+        .gesture(
+            SpatialTapGesture()
+                .targetedToAnyEntity()
+                .onChanged { value in
+                    
                 }
-            }
-            
-        }
+                .onEnded { event in
+                    if event.entity.name == "Welcome" {
+                        let particleEntity = addParticleEntity(transForm: event.entity.transform)
+                        contentEntity.children.forEach {
+                            if $0.name == "Welcome" {
+                                $0.removeFromParent()
+                            }
+                        }
+                        contentEntity.addChild(particleEntity)
+                        
+                        DispatchQueue.main.asyncAfter(
+                            deadline: .now() + 1.5
+                        ) {
+                            particleEntity.removeFromParent()
+                            openWindow(id: "TimerWindow")
+                        }
+                        
+                    }
+                }
+        )
         .toolbar {
             ToolbarItemGroup(placement: .bottomOrnament) {
-                Toggle("Start Game", isOn: $showImmersiveSpace)
+                Text("Tap Welcome Bubble!")
+
             }
         }
+    }
+    private func addParticleEntity(transForm: Transform) -> Entity {
+        let particleEntity = Entity()
+        var emitterComponent = ParticleEmitterComponent()
+        
+        let emitDuration = ParticleEmitterComponent.Timing.VariableDuration(duration: 1.0)
+        emitterComponent.timing = .once(warmUp: nil, emit: emitDuration)
+        emitterComponent.emitterShape = ParticleEmitterComponent.EmitterShape.sphere
+        
+        emitterComponent.speed = 1
+        emitterComponent.mainEmitter.birthRate = 100
+        emitterComponent.mainEmitter.color = .constant(.single(.white))
+        
+        particleEntity.components.set(emitterComponent)
+        particleEntity.transform = transForm
+        // 삭제시 파티클 이름으로 확인
+        particleEntity.name = "particle"
+        return particleEntity
     }
 }
 

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
             let textModelEntity = contentViewModel.makeTextEntity(text: "Welcome", scale: 0.3)
             bubbleEntity.addChild(textModelEntity)
             welcomeEntity.addChild(bubbleEntity)
+            welcomeEntity.position = .init(x: welcomeEntity.position.x, y: welcomeEntity.position.y-0.1, z: welcomeEntity.position.z+0.1)
             content.add(welcomeEntity)
         }
         .gesture(

--- a/AR-BoardGame/AR-BoardGame/View/ContentView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ContentView.swift
@@ -49,7 +49,7 @@ struct ContentView: View {
                             deadline: .now() + 1.5
                         ) {
                             particleEntity.removeFromParent()
-                            openWindow(id: "TimerWindow")
+                            openWindow(id: SceneID.WindowGroup.timer.id)
                         }
                         
                     }

--- a/AR-BoardGame/AR-BoardGame/View/ImmersiveView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ImmersiveView.swift
@@ -33,13 +33,13 @@ struct ImmersiveView: View {
     .onChange(of: viewModel.isResetImmersiveContents) { _ ,newValue in
         if newValue {
             root = viewModel.setUpContentEntity()
-        viewModel.isResetImmersiveContents = false
-      }
+            viewModel.isResetImmersiveContents = false
+        }
     }
   }
 }
 
 #Preview(immersionStyle: .mixed) {
-  ImmersiveView()
-    .environment(ContentViewModel())
+    ImmersiveView()
+        .environment(ContentViewModel())
 }

--- a/AR-BoardGame/AR-BoardGame/View/ImmersiveView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/ImmersiveView.swift
@@ -26,9 +26,6 @@ struct ImmersiveView: View {
     .gesture(
         SpatialTapGesture()
             .targetedToAnyEntity()
-            .onChanged { value in
-                
-            }
             .onEnded { event in
                 viewModel.didTapBubbleEntity(entity: event.entity)
             }

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -8,11 +8,49 @@
 import SwiftUI
 
 struct TimerView: View {
+    @Environment(ContentViewModel.self) var contentViewModel: ContentViewModel
+    @Environment(TimerViewModel.self) var timerViewModel: TimerViewModel
+    @Binding var showImmersiveSpace: Bool
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text("Time: \(timerViewModel.formatTime())")
+                .font(.largeTitle)
+                .padding()
+            
+            VStack {
+                
+                Button{
+                    timerViewModel.resetTimer()
+                    contentViewModel.isResetImmersiveContents = true
+                    timerViewModel.startTimer()
+                } label: {
+                    Text("Reset")
+                        .padding()
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                Button {
+                    timerViewModel.stopTimer()
+                    showImmersiveSpace = false
+                } label: {
+                    Text("Back to Home")
+                        .padding()
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+
+            }
+        }
+        .onAppear {
+            timerViewModel.startTimer()
+        }
+        .onChange(of: contentViewModel.isAllBubbleTapped) { _, newValue in
+            if newValue {
+                timerViewModel.stopTimer()
+                contentViewModel.isAllBubbleTapped = false
+            }
+            
+        }
     }
 }
 
-#Preview {
-    TimerView()
-}

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -35,6 +35,7 @@ struct TimerView: View {
                 }
                 Button {
                     timerViewModel.stopTimer()
+                    contentViewModel.resetContentEnityChild()
                     openWindow(id: "ContentWindow")
                     Task {
                         await dismissImmersiveSpace()
@@ -54,6 +55,7 @@ struct TimerView: View {
         }
         .onChange(of: scenePhase) { _, newScenePhase in
             if newScenePhase == .background {
+                contentViewModel.resetContentEnityChild()
                 openWindow(id: "ContentWindow")
                 Task {
                     await dismissImmersiveSpace()

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -39,6 +39,9 @@ struct TimerView: View {
                 } else {
                     Text("All Bubble Tapped 🎉")
                         .font(.largeTitle)
+                        .onAppear {
+                            timerViewModel.stopTimer()
+                        }
                 }
             
 
@@ -60,9 +63,6 @@ struct TimerView: View {
                         await dismissImmersiveSpace()
                     }
                     dismissWindow(id: SceneID.WindowGroup.timer.id)
-                    Task {
-                        await dismissImmersiveSpace()
-                    }
                 } label: {
                     Text("Back to Home")
                         .padding()
@@ -94,12 +94,6 @@ struct TimerView: View {
                     }
             }
             timerViewModel.startTimer()
-        }
-        .onChange(of: contentViewModel.isAllBubbleTapped) { _, newValue in
-            if newValue {
-                timerViewModel.stopTimer()
-            }
-            
         }
     }
 }

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -55,11 +55,11 @@ struct TimerView: View {
                 Button {
                     timerViewModel.stopTimer()
                     contentViewModel.resetContentEnityChild()
-                    openWindow(id: "ContentWindow")
+                    openWindow(id: SceneID.WindowGroup.content.id)
                     Task {
                         await dismissImmersiveSpace()
                     }
-                    dismissWindow(id: "TimerWindow")
+                    dismissWindow(id: SceneID.WindowGroup.timer.id)
                     Task {
                         await dismissImmersiveSpace()
                     }
@@ -75,16 +75,16 @@ struct TimerView: View {
         .onChange(of: scenePhase) { _, newScenePhase in
             if newScenePhase == .background {
                 contentViewModel.resetContentEnityChild()
-                openWindow(id: "ContentWindow")
+                openWindow(id: SceneID.WindowGroup.content.id)
                 Task {
                     await dismissImmersiveSpace()
                 }
             }
         }
         .onAppear {
-            dismissWindow(id: "ContentWindow")
+            dismissWindow(id: SceneID.WindowGroup.content.id)
             Task {
-                    switch await openImmersiveSpace(id: "ImmersiveSpace") {
+                switch await openImmersiveSpace(id: SceneID.ImmersiveSpace.game.id) {
                     case .opened:
                         debugPrint("ImmersiveSpace opened")
                     case .error, .userCancelled:

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -23,6 +23,25 @@ struct TimerView: View {
                 .padding()
             
             VStack {
+                if !contentViewModel.isAllBubbleTapped {
+                    Text("Tap Bubble Number")
+                        .font(.largeTitle)
+                    Text("\(contentViewModel.getCurrentIndex())")
+                        .font(.extraLargeTitle)
+                        .foregroundStyle(.red)
+                        .padding()
+                        .background {
+                            Circle()
+                                .strokeBorder()
+                                .fill(.clear)
+
+                        }
+                } else {
+                    Text("All Bubble Tapped 🎉")
+                        .font(.largeTitle)
+                }
+            
+
                 Button{
                     timerViewModel.resetTimer()
                     contentViewModel.isResetImmersiveContents = true
@@ -79,7 +98,6 @@ struct TimerView: View {
         .onChange(of: contentViewModel.isAllBubbleTapped) { _, newValue in
             if newValue {
                 timerViewModel.stopTimer()
-                contentViewModel.isAllBubbleTapped = false
             }
             
         }

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -55,14 +55,15 @@ struct TimerView: View {
                         .foregroundColor(.white)
                         .cornerRadius(10)
                 }
+                
                 Button {
+                    dismissWindow(id: SceneID.WindowGroup.timer.id)
                     timerViewModel.stopTimer()
                     contentViewModel.resetContentEnityChild()
                     openWindow(id: SceneID.WindowGroup.content.id)
                     Task {
                         await dismissImmersiveSpace()
                     }
-                    dismissWindow(id: SceneID.WindowGroup.timer.id)
                 } label: {
                     Text("Back to Home")
                         .padding()
@@ -74,6 +75,7 @@ struct TimerView: View {
         }
         .onChange(of: scenePhase) { _, newScenePhase in
             if newScenePhase == .background {
+                timerViewModel.stopTimer()
                 contentViewModel.resetContentEnityChild()
                 openWindow(id: SceneID.WindowGroup.content.id)
                 Task {

--- a/AR-BoardGame/AR-BoardGame/View/TimerView.swift
+++ b/AR-BoardGame/AR-BoardGame/View/TimerView.swift
@@ -1,0 +1,18 @@
+//
+//  TimerView.swift
+//  AR-BoardGame
+//
+//  Created by Damin on 10/2/24.
+//
+
+import SwiftUI
+
+struct TimerView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    TimerView()
+}

--- a/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
+++ b/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
@@ -18,9 +18,15 @@ class ContentViewModel {
     private var textBoundingBox = BoundingBox.empty
     
     private var currentIndex = 1
-    private var countOfBubbles = 20
+    private var countOfBubbles = 10
     private var addedChildList: [Entity] = []
+    
+    func getCurrentIndex() -> Int {
+        currentIndex
+    }
+    
     func resetContentEnityChild() {
+        isAllBubbleTapped = false
         for child in addedChildList {
             contentEntity.removeChild(child)
         }
@@ -179,8 +185,9 @@ class ContentViewModel {
             }
             if currentIndex == countOfBubbles {
                 isAllBubbleTapped = true
+            } else {
+                currentIndex += 1
             }
-            currentIndex += 1
 
         } else {
             

--- a/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
+++ b/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
@@ -19,10 +19,12 @@ class ContentViewModel {
     
     private var currentIndex = 1
     private var countOfBubbles = 20
+    private var addedChildList: [Entity] = []
     func resetContentEnityChild() {
-        for child in contentEntity.children {
+        for child in addedChildList {
             contentEntity.removeChild(child)
         }
+        addedChildList = []
     }
     
     func setUpContentEntity() -> Entity {
@@ -48,7 +50,7 @@ class ContentViewModel {
             
             modelEntity.generateCollisionShapes(recursive: true)
             modelEntity.components.set(InputTargetComponent(allowedInputTypes: .all))
-            
+            addedChildList.append(modelEntity)
             contentEntity.addChild(modelEntity)
         }
         
@@ -140,7 +142,6 @@ class ContentViewModel {
             
             coordinates.append(newEntityCoordinate)
         }
-        
         return coordinates
     }
     
@@ -162,7 +163,11 @@ class ContentViewModel {
         
         if entity.name == "index-\(currentIndex)" {
             entity.removeFromParent()
-            
+            for (idx, child) in addedChildList.enumerated() {
+                if child.name == "index-\(currentIndex)" {
+                    addedChildList.remove(at: idx)
+                }
+            }
             addParticleEntity (
                 transForm: entity.transform
             ) { entity in

--- a/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
+++ b/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
@@ -18,7 +18,7 @@ class ContentViewModel {
     private var textBoundingBox = BoundingBox.empty
     
     private var currentIndex = 1
-    private var countOfBubbles = 10
+    private var countOfBubbles = 5
     private var addedChildList: [Entity] = []
     
     func getCurrentIndex() -> Int {
@@ -53,9 +53,18 @@ class ContentViewModel {
                 y: Float(coor.y),
                 z: Float(coor.z)
             )
+//            let modelComponent = ModelComponent(
+//                mesh: MeshResource.generateBox(size: boxSize),
+//                materials: [SimpleMaterial(color: .black, roughness: 0.5, isMetallic: false)]
+//            )
+//            let collisionComponent = CollisionComponent(
+//                shapes: [ShapeResource.generateSphere(radius: 0.3)]
+//            )
+            let inputTargetComponent = InputTargetComponent(allowedInputTypes: .all)
+            let hoverEffectComponent = HoverEffectComponent()
             
             modelEntity.generateCollisionShapes(recursive: true)
-            modelEntity.components.set(InputTargetComponent(allowedInputTypes: .all))
+            modelEntity.components.set([inputTargetComponent, hoverEffectComponent])
             addedChildList.append(modelEntity)
             contentEntity.addChild(modelEntity)
         }

--- a/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
+++ b/AR-BoardGame/AR-BoardGame/ViewModel/ContentViewModel.swift
@@ -12,12 +12,13 @@ import RealityKitContent
 @Observable
 class ContentViewModel {
     var isResetImmersiveContents = false
+    var isAllBubbleTapped = false
     var contentEntity = Entity()
     private let modelScale: Float = 0.3
     private var textBoundingBox = BoundingBox.empty
     
     private var currentIndex = 1
-    
+    private var countOfBubbles = 20
     func resetContentEnityChild() {
         for child in contentEntity.children {
             contentEntity.removeChild(child)
@@ -128,7 +129,7 @@ class ContentViewModel {
         // 내 뒤에까지 방울을 배치
         let zRange: ClosedRange<Float> = -1.0 ... 0.5
         
-        for _ in 0..<30 {
+        for _ in 0..<countOfBubbles {
             var newEntityCoordinate: EntityCoordinate
             repeat {
                 let randomX = Float.random(in: xRange)
@@ -160,7 +161,6 @@ class ContentViewModel {
     func didTapBubbleEntity(entity: Entity) {
         
         if entity.name == "index-\(currentIndex)" {
-            currentIndex += 1
             entity.removeFromParent()
             
             addParticleEntity (
@@ -172,6 +172,11 @@ class ContentViewModel {
                     entity.removeFromParent()
                 }
             }
+            if currentIndex == countOfBubbles {
+                isAllBubbleTapped = true
+            }
+            currentIndex += 1
+
         } else {
             
             if let modelEntity = entity as? ModelEntity {

--- a/AR-BoardGame/AR-BoardGame/ViewModel/TimerViewModel.swift
+++ b/AR-BoardGame/AR-BoardGame/ViewModel/TimerViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  TimerViewModel.swift
+//  AR-BoardGame
+//
+//  Created by Damin on 10/2/24.
+//
+
+import SwiftUI
+
+@Observable
+class TimerViewModel {
+    var timeElapsed: TimeInterval = 0
+    private var timer: Timer?
+    private var startDate: Date?
+
+    func startTimer() {
+        startDate = Date()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            guard let startDate = self?.startDate else { return }
+            self?.timeElapsed = Date().timeIntervalSince(startDate)
+        }
+    }
+
+    func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func resetTimer() {
+        timeElapsed = 0
+        stopTimer()
+    }
+
+    func formatTime() -> String {
+        let minutes = Int(timeElapsed) / 60
+        let seconds = Int(timeElapsed) % 60
+        let milliseconds = Int((timeElapsed - Double(Int(timeElapsed))) * 100)
+        return String(format: "%02d:%02d.%02d", minutes, seconds, milliseconds)
+    }
+}


### PR DESCRIPTION
## 🔥 작업한 내용
- 모든 버블을 터트렸을 때는 currentIndex가 전체 버블의 수의 비교를 통해 판단
- TimerView 에서 타이머와 reset, backToHome 버튼 구현
- TimerView에서 BackToHome 버튼 클릭시 showImmsersiveSpace 상태 값을 ContentViewModel로 옮겼었는데ContentView의 toolBar 모디파이어 내에서 Toggle의 isOn 파라미터에 viewModel에 있는 상태값이 바인딩이 안돼서 아예 TimerView와 ContentView에서 @binding으로 showImmsersiveSpace을 받아서 사용되도록 수정
- ContentView의 버블을 탭해서 TimerWindow를 띄우는 것으로 수정
- TimerView onAppear시 ImmersiveSpace를 실행하도록 변경하여 기존에 ContentView에 있던 ImmersivewSpace 환경 변수 및 로직을 TimerView로 이동
- TimerView onAppear시 ContentWindow를 닫고 ImmersiveSpace를 열고, BackToHome 버튼 클릭시와 TimerWindow를 닫을때, TimerWindow, ImmersiveSpace를 닫고, ContentWindow를 열도록 수정
- 현재 탭해야 되는 버블 숫자를 표시하고 모든 버블을 탭 했을때 축하 문자 표시

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
### 버그 수정
- contentEntity의 children을 이용해서 for문을 돌려서 content이 child 엔터티들을 reset해줬는데, 이때 API상의 버그로 children 엔터티 배열로 모든 자식엔터티가 나오지 않아서 content의 child가 다 지워지지 않는 문제가 있음
- 때문에 추가한 child들을 관리할 배열을 따로 만들어서 엔터티를 추가할때 배열에 같이 추가하고 엔터티를 삭제할때 같이 배열에서도 삭제하여 배열을 통해 child 엔터티들을 관리하여 reset 할때 배열에 있는 엔터티들을 이용해서 contentEntity의 reset 구현

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
### contentEntity.chidren으로 for문 돌릴때 - 일부 엔터티들이 안 나옴
<img width="215" alt="Screenshot 2024-10-05 at 5 40 24 PM" src="https://github.com/user-attachments/assets/ae36154f-8c70-45fc-b8a2-1726c536e386">

### 버블을 탭해서 진입
![Simulator Screen Recording - Apple Vision Pro - 2024-10-05 at 18 09 32](https://github.com/user-attachments/assets/b79b1af9-1918-4334-96d9-d25fd298f978)


## 🚨 관련 이슈
- Resolved: #8 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
